### PR TITLE
Addition of External Referral dropdown option on Channel field

### DIFF
--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -364,7 +364,7 @@ class Applicant(models.Model):
     x_app_source_category = fields.Selection(
         [('online-digital', 'Online-Digital'), ('proactive_search', 'Pro-active Search'),
          ('recruitment-marketing', 'Recruitment-Marketing'), ('employee referral', 'Employee Referral'),
-         ('rehire', 'Rehire'), ('open house', 'Open House')],
+         ('rehire', 'Rehire'), ('open house', 'Open House'), ('external_referral', 'External Referral')],
         'Channel', store=True, tracking=True)
     x_app_specific_source_last = fields.Many2one('hr.specificsource', required=False, string='Specific Source',
                                                  domain="[('x_app_source_category','=','proactive_search')]",
@@ -1240,6 +1240,10 @@ class Applicant(models.Model):
                 specific_source = self.env['hr.specificsource'].search(
                     [('x_app_specific_source_new', '=', 'Rehire')], limit=1)
                 rec.x_app_specific_source_last = specific_source.id if specific_source else False
+            if rec.x_app_source_category == 'external_referral':
+                specific_source = self.env['hr.specificsource'].search(
+                    [('x_app_specific_source_new', '=', 'External Referral')], limit=1)
+                rec.x_app_specific_source_last = specific_source.id if specific_source else False
             if not rec.x_app_source_category == 'employee referral':
                 rec.x_referrer_name = ''
 
@@ -1833,7 +1837,7 @@ class SpecificSource(models.Model):
     x_app_source_category = fields.Selection(
         [('online-digital', 'Online-Digital'), ('proactive_search', 'Pro-active Search'),
          ('recruitment-marketing', 'Recruitment-Marketing'), ('employee referral', 'Employee Referral'),
-         ('rehire', 'Rehire'), ('open house', 'Open House')],
+         ('rehire', 'Rehire'), ('open house', 'Open House'), ('external_referral', 'External Referral')],
         'Channel', store=True)
 
 class ApplicantCategory(models.Model):


### PR DESCRIPTION
- Addition of a new Channel dropdown option "External Referral" on both hr.applicant and hr.specificsource model.
- Auto populating "External Referral" data on Specific Source field once "External Referral" is selected.
- Specific Source will not be invisible after selecting "External Referral" on Channel field only readonly.