### PR TITLE
Resetting of Date Fields

### DIFF
--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -729,9 +729,32 @@ class Applicant(models.Model):
             rec.initial_touch_date = False
             rec.x_application_category = False
             rec.x_application_stage_ownership = False
-            rec.stage_id = False
+            rec.stage_id = 1
             if not self._origin.x_reprofile_logs == False:
                 rec.reprofiled_identifier = True
+            
+            # Added fields to remove value
+            rec.x_date_dispatched = False
+            rec.x_touch_date = False
+            rec.x_status_dropdown = False
+            # CPS
+            rec.x_cps_endorsement = False
+            rec.x_cps_result = False
+            rec.x_cps_result_date = False
+            # CI
+            rec.x_ci_date = False
+            rec.x_ci_result = False
+            rec.x_ci_result_date = False
+            # DA
+            rec.x_date_sent_assessment = False
+            # 2nd CI
+            rec.x_second_ci_date = False
+            rec.x_second_ci_result = False
+            rec.x_second_ci_result_date = False
+            # 3nd CI
+            rec.x_third_ci_date = False
+            rec.x_third_ci_result = False
+            rec.x_third_ci_result_date = False
 
     # Applicant Stage Funneling
     @api.onchange('stage_id')


### PR DESCRIPTION
1.Automation for Candidates Based on Requisition Status:

Candidates with Movement:
If a requisition is marked as On-Hold, Cancelled, Filled, or Completed, candidates in these stages should be automatically tagged as "Active File: No Positions Available".
Candidates Without Movement (e.g., Untapped):
If a requisition is marked as On-Hold, Cancelled, Filled, or Completed, candidates without activity should be automatically tagged as "No Positions Available."
 

2. Additional Stage:

Introduce a new stage called "Pending CV" under the Pooling/Recruitment category for:
Candidates lacking a CV.
Candidates identified through proactive search.
 

3. Dates and Days processed

When a candidate is being reprofiled, all associated days should be reset to zero, ensuring a fresh start for tracking purposes. 
These changes will help improve our workflow by ensuring consistency and accuracy in candidate tracking while reducing manual intervention.